### PR TITLE
Add sdr-native color mode to support GNOME 50

### DIFF
--- a/src/display_config.rs
+++ b/src/display_config.rs
@@ -126,6 +126,7 @@ pub mod get_current_state {
         Default = 0,
         /// HDR
         BT2100 = 1,
+        SDRNative = 2,
     }
 
     #[derive(Debug, Clone, Type, Serialize, Deserialize)]


### PR DESCRIPTION
Closes https://github.com/eaglesemanation/displayconfig-mutter/issues/6