### PR TITLE
Feat: Save/load logical monitors to/from a file

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,9 +16,9 @@ pub enum Command {
     /// Set config
     Set(SetArgs),
     /// Save the current logical monitor configuration to a file
-    SaveFile(GetRawArgs),
+    SaveFile(SaveFileArgs),
     /// Load the logical monitor configuration from a file
-    LoadFile(SetRawArgs),
+    LoadFile(LoadFileArgs),
 }
 
 #[derive(Debug, Args)]
@@ -74,13 +74,13 @@ pub struct SetArgs {
 }
 
 #[derive(Debug, Args)]
-pub struct GetRawArgs {
+pub struct SaveFileArgs {
     /// Save data to this file
     pub file_path: PathBuf,
 }
 
 #[derive(Debug, Args)]
-pub struct SetRawArgs {
+pub struct LoadFileArgs {
     /// Load data from this file
     pub file_path: PathBuf,
     /// Save config to the disk after applying it. Will prompt for user input to verify if it's

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
@@ -13,6 +15,10 @@ pub enum Command {
     List(ListArgs),
     /// Set config
     Set(SetArgs),
+    /// Save the current logical monitor configuration to a file
+    SaveFile(GetRawArgs),
+    /// Load the logical monitor configuration from a file
+    LoadFile(SetRawArgs),
 }
 
 #[derive(Debug, Args)]
@@ -65,6 +71,22 @@ pub struct SetArgs {
     /// Controls display color mode
     #[arg(value_enum, long, conflicts_with = "hdr")]
     pub color_mode: Option<ColorMode>,
+}
+
+#[derive(Debug, Args)]
+pub struct GetRawArgs {
+    /// Save data to this file
+    pub file_path: PathBuf,
+}
+
+#[derive(Debug, Args)]
+pub struct SetRawArgs {
+    /// Load data from this file
+    pub file_path: PathBuf,
+    /// Save config to the disk after applying it. Will prompt for user input to verify if it's
+    /// correct
+    #[arg(short, long)]
+    pub persistent: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
                     "could not find neither current mode nor preferred mode"
                 ))?;
 
-            let mut logical_monitors = new_logical_monitors(current_state.clone())?;
+            let mut logical_monitors = new_logical_monitors(&current_state)?;
             if args.primary {
                 for monitor in &mut logical_monitors {
                     monitor.primary = false;
@@ -354,16 +354,16 @@ fn match_color_mode(
 /// Produces a list of logical monitors in apply_monitors_config format that would keep the same
 /// configuration as current_state
 fn new_logical_monitors(
-    current_state: get_current_state::Response,
+    current_state: &get_current_state::Response,
 ) -> anyhow::Result<Vec<apply_monitors_config::LogicalMonitor>> {
     let mut out = vec![];
-    for logical_monitor in current_state.logical_monitors {
+    for logical_monitor in &current_state.logical_monitors {
         let mut monitors = vec![];
-        for monitor_id in logical_monitor.monitors {
+        for monitor_id in &logical_monitor.monitors {
             let monitor = current_state
                 .monitors
                 .iter()
-                .find(|monitor| monitor.id == monitor_id)
+                .find(|monitor| &monitor.id == monitor_id)
                 .ok_or(anyhow!(
                     "Logical monitor references \"{} {}\" ({}), but it's not found",
                     monitor_id.vendor,
@@ -381,7 +381,7 @@ fn new_logical_monitors(
                     monitor_id.connector
                 ))?;
             monitors.push(apply_monitors_config::Monitor {
-                connector: monitor_id.connector,
+                connector: monitor_id.connector.to_owned(),
                 mode: current_mode.id.clone(),
                 properties: apply_monitors_config::MonitorProperties {
                     underscanning: monitor.properties.is_underscanning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,12 @@ use tabled::{
     builder::Builder,
     settings::{object::Rows, Alignment, Modify, Style},
 };
+use tokio::fs;
+use zbus::zvariant::{
+    self,
+    serialized::{Context, Data},
+    LE,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -179,6 +185,42 @@ async fn main() -> anyhow::Result<()> {
                     logical_monitor.y += target_height - current_height;
                 }
             }
+
+            proxy
+                .apply_monitors_config(
+                    current_state.serial,
+                    if args.persistent {
+                        apply_monitors_config::Method::Persistent
+                    } else {
+                        apply_monitors_config::Method::Temporary
+                    },
+                    logical_monitors,
+                    apply_monitors_config::Properties {
+                        layout_mode: None,
+                        monitors_for_lease: None,
+                    },
+                )
+                .await?;
+        }
+        cli::Command::SaveFile(args) => {
+            let logical_monitors = new_logical_monitors(&current_state)?;
+
+            let context = Context::new_dbus(LE, 0);
+            let encoded = zvariant::to_bytes(context, &logical_monitors)?;
+
+            if let Some(parent) = args.file_path.parent() {
+                fs::create_dir_all(parent).await?;
+            }
+            fs::write(args.file_path, encoded).await?;
+        }
+        cli::Command::LoadFile(args) => {
+            let encoded = fs::read(args.file_path).await?;
+
+            let context = Context::new_dbus(LE, 0);
+            let data = Data::new(encoded, context);
+
+            let logical_monitors: Vec<apply_monitors_config::LogicalMonitor> =
+                data.deserialize()?.0;
 
             proxy
                 .apply_monitors_config(


### PR DESCRIPTION
Resolves #9

Example usage:
```bash
# Save current settings
displayconfig-mutter save-file /tmp/mutter/original-config
# Make some changes
displayconfig-mutter set --connector DP-2 --disable
# Undo those changes
displayconfig-mutter load-file /tmp/mutter/original-config
```

Some notes:
- I used a binary file format instead of something like json since the `zbus::zvariant` types weren't deserializable by serde_json.
- Only the `logical_monitors` are stored, not other data like `serial`, `monitors`, or `properties`. Can be changed if you'd like.
- The `--disable` flag from v0.1.9 doesn't work for me, reported in https://github.com/eaglesemanation/displayconfig-mutter/issues/11